### PR TITLE
fix typos in links

### DIFF
--- a/pages/guide/01-start.md
+++ b/pages/guide/01-start.md
@@ -9,7 +9,7 @@ title: Getting Started
 The easiest way to get started with Elide is to use the elide-standalone library. The standalone library bundles all of
 the dependencies you will need to stand up a web service. This tutorial will use elide-standalone, all of the code is
 [available here][elide-demo]–if you want to see a more fully fleshed out example of the standalone library checkout this
-[Kotlyn blog example][kotlyn-blog].
+[Kotlin blog example][kotlin-blog].
 
 1. Contents
 {:toc}
@@ -261,7 +261,7 @@ curl -X PATCH http://localhost:8080/api/v1/group/com.example.repository/products
 It’s just that easy to create and update data using Elide.
 
 [elide-demo]: https://github.com/clayreimann/elide-demo
-[kotlyn-blog]: https://github.com/DennisMcWherter/elide-example-blog-kotlin
-[demo-schema]: /pages/resource/demo.sql
+[kotlin-blog]: https://github.com/DennisMcWherter/elide-example-blog-kotlin
+[demo-schema]: /pages/resources/demo.sql
 [hibernate-conf]: /pages/resources/hibernate.cfg.xml
 [logback-conf]: /pages/resources/logback.xml


### PR DESCRIPTION
kotlyn -> kotlin (https://kotlinlang.org/)
demo.sql path
Fixes Issue#71